### PR TITLE
Fixed module import and typos

### DIFF
--- a/docs/main-sidebar.md
+++ b/docs/main-sidebar.md
@@ -1,7 +1,7 @@
 Sidebar
 =======
 
-`import { Sidebar } from 'reactjs-admin-lte';`
+`import { MainSidebar } from 'reactjs-admin-lte';`
 
 Here is an example of the [sidebar component][sidebar-component].
 
@@ -16,7 +16,7 @@ Here is an example of the [sidebar component][sidebar-component].
 ---
 
 ## MainSidebar
-`<MaineSidebar>` - The [main sidebar component][sidebar-component]. Goes on the left-hand side of the screen.
+`<MainSidebar>` - The [main sidebar component][sidebar-component]. Goes on the left-hand side of the screen.
 
 #### Props
  - __children__ (node) - What you want to put in the sidebar.


### PR DESCRIPTION
The import statement  `import { Sidebar }` is incorrect, we need to use `import { MainSidebar }` instead. Also corrected a small error in spelling.